### PR TITLE
updates api key env var name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Once you have your API key, create a .env file and add the key!
 
 ```bash
 touch .env
-echo "API_KEY=\"<INSERT_GENAI_API_KEY>\"" > .env
+echo "GENAI_API_KEY=\"<INSERT_GENAI_API_KEY>\"" > .env
 ```
 
 Remember, use your API keys securely. Do not share them with others, or embed


### PR DESCRIPTION
 models/genai/api.ts refers to `GENAI_API_KEY` while the README mentions `API_KEY` - this updates the README file to have the user create the proper env var (`GENAI_API_KEY`)