### PR TITLE
Code Update: Corrected Method Call to buildRewriteEndOfSentenceExamples(context)

### DIFF
--- a/app/context/index.ts
+++ b/app/context/index.ts
@@ -40,6 +40,7 @@ import {
   buildFirstSentenceExamples,
   buildGenerateWithinSentenceExamples,
   buildNextSentenceExamples,
+  buildRewriteEndOfSentenceExamples,
 } from './examples_from_stories';
 
 import {OperationType} from '@core/shared/types';
@@ -126,7 +127,7 @@ export class WordcraftContext {
       nextSentenceExamples
     );
 
-    const rewriteEndOfSentenceExamples = buildNextSentenceExamples(context);
+    const rewriteEndOfSentenceExamples = buildRewriteEndOfSentenceExamples(context);
     this.registerExamples(
       OperationType.REWRITE_END_OF_SENTENCE,
       rewriteEndOfSentenceSchema,


### PR DESCRIPTION
Updated the code by importing and substituting the incorrect method call with the correct one, 'buildRewriteEndOfSentenceExamples(context)'.