### PR TITLE
Update env var

### DIFF
--- a/app/models/palm/api.ts
+++ b/app/models/palm/api.ts
@@ -102,7 +102,7 @@ export async function callApi(
 ) {
   const urlPrefix = `${API_URL}/models/${modelId}:${method}`;
   const url = new URL(urlPrefix);
-  url.searchParams.append('key', process.env.PALM_API_KEY);
+  url.searchParams.append('key', process.env.API_KEY);
 
   return fetch(url.toString(), {
     method: 'POST',


### PR DESCRIPTION
Based on the Wordcraft docs (https://ai.google.dev/develop/sample-apps/wordcraft), this variable should be API_KEY (see step three in "Environmental Variables). User hits a console error if they do not change this.